### PR TITLE
Adds yo as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "yeoman-generator": "~0.12.0"
   },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
+  },
   "devDependencies": {
     "mocha": "~1.9.0"
   },


### PR DESCRIPTION
As `yo` specifies `grunt-cli` and `bower` as peerDependencies, this should allow a `npm install -g generator-pure` to install all three of them globally. Users will no longer need to install them separately prior.
